### PR TITLE
net-smtpの警告を解消した

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -63,5 +63,6 @@ end
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'html2slim'
+gem 'net-smtp', require: false
 gem 'slim-rails'
 gem 'tailwindcss-rails', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -64,6 +64,7 @@ gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'html2slim'
 gem 'net-imap', require: false
+gem 'net-pop', require: false
 gem 'net-smtp', require: false
 gem 'slim-rails'
 gem 'tailwindcss-rails', '~> 2.0'

--- a/Gemfile
+++ b/Gemfile
@@ -63,6 +63,7 @@ end
 gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'html2slim'
+gem 'net-imap', require: false
 gem 'net-smtp', require: false
 gem 'slim-rails'
 gem 'tailwindcss-rails', '~> 2.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -109,6 +109,8 @@ GEM
     msgpack (1.6.0)
     net-imap (0.3.1)
       net-protocol
+    net-pop (0.1.2)
+      net-protocol
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.2)
@@ -266,6 +268,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   listen (~> 3.3)
   net-imap
+  net-pop
   net-smtp
   pg (~> 1.1)
   puma (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,8 @@ GEM
     mini_mime (1.1.2)
     minitest (5.16.3)
     msgpack (1.6.0)
+    net-imap (0.3.1)
+      net-protocol
     net-protocol (0.1.3)
       timeout
     net-smtp (0.3.2)
@@ -263,6 +265,7 @@ DEPENDENCIES
   html2slim
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  net-imap
   net-smtp
   pg (~> 1.1)
   puma (~> 5.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -107,6 +107,10 @@ GEM
     mini_mime (1.1.2)
     minitest (5.16.3)
     msgpack (1.6.0)
+    net-protocol (0.1.3)
+      timeout
+    net-smtp (0.3.2)
+      net-protocol
     nio4r (2.5.8)
     nokogiri (1.13.9-x86_64-darwin)
       racc (~> 1.4)
@@ -220,6 +224,7 @@ GEM
     temple (0.8.2)
     thor (1.2.1)
     tilt (2.0.11)
+    timeout (0.3.0)
     turbolinks (5.2.1)
       turbolinks-source (~> 5.2)
     turbolinks-source (5.2.0)
@@ -258,6 +263,7 @@ DEPENDENCIES
   html2slim
   jbuilder (~> 2.7)
   listen (~> 3.3)
+  net-smtp
   pg (~> 1.1)
   puma (~> 5.0)
   rack-mini-profiler (~> 2.0)


### PR DESCRIPTION
## Issue
- #34 

## 変更点
- net-smtpを導入
- net-imapを導入
- net-popを導入

参考：[Rails 6.1.5で uninitialized constant Mail::TestMailer というエラーが出る場合の対処法](https://qiita.com/jnchito/items/4ef331281f0050428716)
