### PR TITLE
システムテストのデフォルト設定を変更

### DIFF
--- a/test/application_system_test_case.rb
+++ b/test/application_system_test_case.rb
@@ -3,5 +3,9 @@
 require 'test_helper'
 
 class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
-  driven_by :selenium, using: :chrome, screen_size: [1400, 1400]
+  if ENV['HEADED']
+    driven_by :selenium, using: :chrome
+  else
+    driven_by :selenium, using: :headless_chrome
+  end
 end


### PR DESCRIPTION
## Issue
- #4 

## 変更点

以下のエラーに対応するため、`driven_by`の設定を変更しました。

```
Error:
WelcomeTest#test_GET_/:
Selenium::WebDriver::Error::UnknownError: unknown error: Chrome failed to start: exited abnormally.
  (unknown error: DevToolsActivePort file doesn't exist)
  (The process started from chrome location /usr/bin/google-chrome is no longer running, so ChromeDriver is assuming that Chrome has crashed.)
```

参考：https://railsguides.jp/testing.html#デフォルト設定の変更
