### PR TITLE
リサイズ機能を追加

### DIFF
--- a/app/javascript/upload-media.vue
+++ b/app/javascript/upload-media.vue
@@ -116,14 +116,29 @@ export default {
       this.ctx.clearRect(0, 0, this.canvasWidth, this.canvasHeight)
 
       img.onload = () => {
-        this.canvasWidth = img.width
-        this.canvasHeight = img.height
+        const maxWidth = 1280
+        const maxHeight = 640
+        if (img.width > maxWidth || img.height > maxHeight) {
+          this.resizeCanvas(img.width, img.height, maxWidth, maxHeight)
+        } else {
+          this.canvasWidth = img.width
+          this.canvasHeight = img.height
+        }
         canvas.width = this.canvasWidth
         canvas.height = this.canvasHeight
         this.ctx.drawImage(img, 0, 0, this.canvasWidth, this.canvasHeight)
         this.addText(this.ctx, position)
         this.imageDataUrl = canvas.toDataURL()
         return this.canvas
+      }
+    },
+    resizeCanvas(imgWidth, imgHeight, maxWidth, maxHeight) {
+      if (imgWidth > imgHeight * 2) {
+        this.canvasHeight = (maxWidth * imgHeight) / imgWidth
+        this.canvasWidth = (this.canvasHeight * imgWidth) / imgHeight
+      } else {
+        this.canvasWidth = (maxHeight * imgWidth) / imgHeight
+        this.canvasHeight = (this.canvasWidth * imgHeight) / imgWidth
       }
     },
     addText(ctx, position) {

--- a/app/javascript/upload-media.vue
+++ b/app/javascript/upload-media.vue
@@ -142,7 +142,7 @@ export default {
       }
     },
     addText(ctx, position) {
-      const fontSize = 48
+      const fontSize = this.canvasWidth / 20
       this.ctx.font = `bold ${fontSize}px Arial`
       this.ctx.fillStyle = 'rgba(31, 41, 55, 0.3)'
       if (position === 'centerCenter') {


### PR DESCRIPTION
## Issue
- #111 

## 変更点
透かしテキストサイズを画像幅にあわせて可変にしました。
画像サイズの上限（1280x640）を設定しました。
参考：https://mieru-ca.com/blog/twitter_image-size/
<img width="450" alt="image" src="https://user-images.githubusercontent.com/60736158/214868994-0d081ed0-8827-4c5e-b088-d7a20dfccc92.png">
